### PR TITLE
Emulating a real version of chrome. Headless mode have special user agent

### DIFF
--- a/server/browser.js
+++ b/server/browser.js
@@ -48,6 +48,7 @@ export async function withPage(fn) {
   try {
     page = await browser.newPage();
     page._client.send('Network.setBypassServiceWorker', {bypass: true});
+    await page.setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.47 Safari/537.36');
     await page.setRequestInterception(true);
     page.on('request', interceptRequest);
     return await fn(page);


### PR DESCRIPTION
Thanks for the great instrument. I checked my site https://www.tinkoff.ru/ and noticed that estimator don't send user agent from the new Browser.

estimator use puppeter in headless mode and send user agent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/88.0.4298.0 Safari/537.36` this user agent unusual

I replace this value and emulate real browser